### PR TITLE
update description, homepage, and source-repository in .cabal file

### DIFF
--- a/aztecs.cabal
+++ b/aztecs.cabal
@@ -1,13 +1,23 @@
-cabal-version: 3.0
+cabal-version: 2.4
 name:          aztecs
 version:       0.2.0.0
 license:       BSD-3-Clause
 license-file:  LICENSE
 maintainer:    matt@hunzinger.me
 author:        Matt Hunzinger
-synopsis:      A type-safe and friendly ECS for Haskell 
-description:   A type-safe and friendly ECS for Haskell 
+synopsis:      A type-safe and friendly Entity-Component-System (ECS) for Haskell
+description:   The Entity-Component-System (ECS) pattern is commonly used in video game develop to represent world objects.
+               .
+               ECS follows the principal of composition over inheritence. Each type of
+               object (e.g. sword, monster, etc), in the game has a unique EntityId. Each
+               entity has various Components associated with it (material, weight, damage, etc).
+               Systems act on entities which have the required Components.
+homepage:      https://github.com/matthunz/aztecs
 category:      Game Engine
+
+source-repository head
+    type:     git
+    location: https://github.com/matthunz/aztecs.git
 
 library
     exposed-modules:


### PR DESCRIPTION
Added the words 'Entity-Component-System' to the synopsis and added a short description so that people might have some idea if they even need an ECS.  This should also improve SEO. Feel free to improve the description. 

Lowered the minimum cabal-version to 2.4, since no cabal 3.0 features are used in the .cabal file. This was the only thing preventing me from building with GHC 8.6.5.

Added the `homepage` and `source-repository` fields so that people can easily find the github repo when viewing the package on hackage.
